### PR TITLE
Add a "linear" eazing function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,12 @@ fn lit<F: Float>(f: f64) -> F {
   F::from(f).unwrap()
 }
 
+// Linear
+
+#[inline]
+pub fn linear<F: Float>(t: F) -> F {
+  t
+}
 
 // Quadratic
 


### PR DESCRIPTION
Having a linear function is helpful as an alternative to an `Option<fn(f64) -> f64>`